### PR TITLE
feat: release for the new gravitee-inference-api.version v1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
     <version>2.1.0</version>
 
     <name>Gravitee.io APIM - Resource - AI Model API</name>
+    <description>This is the base API for the AI model resources</description>
 
     <properties>
         <gravitee-bom.version>8.3.34</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-
         <maven-plugin-javadoc.version>3.11.2</maven-plugin-javadoc.version>
         <maven-plugin-prettier.version>0.22</maven-plugin-prettier.version>
         <maven-plugin-prettier.prettierjava.version>2.0.0</maven-plugin-prettier.prettierjava.version>
@@ -56,7 +56,6 @@
     </dependencyManagement>
 
     <dependencies>
-
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/src/main/java/io/gravitee/resource/ai_model/api/AiTextModelResource.java
+++ b/src/main/java/io/gravitee/resource/ai_model/api/AiTextModelResource.java
@@ -40,7 +40,6 @@ public abstract class AiTextModelResource<C extends ResourceConfiguration, MODEL
         super.doStart();
         vertx = applicationContext.getBean(Vertx.class);
         inferenceServiceClient = buildInferenceServiceClient();
-
         fetchModel();
     }
 


### PR DESCRIPTION
This PR fixes a few typos and activates the release for the  gravitee-inference-api.version v1.5.0
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-fix-typos-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-api/2.2.0-fix-typos-SNAPSHOT/gravitee-resource-ai-model-api-2.2.0-fix-typos-SNAPSHOT.zip)
  <!-- Version placeholder end -->
